### PR TITLE
Enable saving bolometer etendues to file

### DIFF
--- a/demos/diagnostic/kb1/calculate_etendues.py
+++ b/demos/diagnostic/kb1/calculate_etendues.py
@@ -80,6 +80,9 @@ def calculate_etendue(self, ray_count=10000, batches=10):
     return etendue, etendue_error
 
 
+kb1_etendues = []
 for detector in kb1:
     etendue, etendue_error = calculate_etendue(detector, ray_count=1000000)
     print("Detector {}: etendue {:.4G} +- {:.3G} m^2 str".format(detector.name, etendue, etendue_error))
+    kb1_etendues.append((etendue, etendue_error))
+    np.save("kb1_etendue.npy", kb1_etendues)

--- a/demos/diagnostic/kb5/calculate_etendues.py
+++ b/demos/diagnostic/kb5/calculate_etendues.py
@@ -1,4 +1,4 @@
-
+import numpy as np
 
 from raysect.primitive import import_obj
 from raysect.optical import World
@@ -15,16 +15,21 @@ kb5v_collimator_mesh = import_obj(KB5V[0][0], scaling=0.001, name='kb5v_collimat
 kb5h_collimator_mesh = import_obj(KB5H[0][0], scaling=0.001, name='kb5h_collimator',
                                   parent=world, material=AbsorbingSurface())
 
-
 kb5v = load_kb5_camera('KB5V', parent=world)
+kb5v_etendues = []
 for detector in kb5v:
 
     etendue, etendue_error = detector.calculate_etendue(ray_count=400000)
     print("Detector {}: etendue {:.4G} +- {:.3G} m^2 str".format(detector.name, etendue, etendue_error))
+    kb5v_etendues.append((etendue, etendue_error))
+np.save("kb5v_etendue.npy", kb5v_etendues)
 
 
 kb5h = load_kb5_camera('KB5H', parent=world)
+kb5h_etendues = []
 for detector in kb5h:
 
     etendue, etendue_error = detector.calculate_etendue(ray_count=400000)
     print("Detector {}: etendue {:.4G} +- {:.3G} m^2 str".format(detector.name, etendue, etendue_error))
+    kb5h_etendues.append((etendue, etendue_error))
+np.save("kb5h_etendue.npy", kb5h_etendues)


### PR DESCRIPTION
Previously etendues were just printed, but saving to file is more
useful for later re-use.