### PR TITLE
Include KB5 camera geometry when loading the cameras

### DIFF
--- a/demos/diagnostic/kb5/calculate_etendues.py
+++ b/demos/diagnostic/kb5/calculate_etendues.py
@@ -1,34 +1,25 @@
 import numpy as np
 
-from raysect.primitive import import_obj
 from raysect.optical import World
 from raysect.optical.material import AbsorbingSurface
 
-from cherab.jet.machine.cad_files import KB5V, KB5H
 from cherab.jet.bolometry import load_kb5_camera
 
 
-# Calculate KB5V camera sensitivities
 world = World()
-kb5v_collimator_mesh = import_obj(KB5V[0][0], scaling=0.001, name='kb5v_collimator',
-                                  parent=world, material=AbsorbingSurface())
-kb5h_collimator_mesh = import_obj(KB5H[0][0], scaling=0.001, name='kb5h_collimator',
-                                  parent=world, material=AbsorbingSurface())
 
-kb5v = load_kb5_camera('KB5V', parent=world)
+kb5v = load_kb5_camera('KB5V', parent=world, override_material=AbsorbingSurface())
 kb5v_etendues = []
 for detector in kb5v:
-
     etendue, etendue_error = detector.calculate_etendue(ray_count=400000)
     print("Detector {}: etendue {:.4G} +- {:.3G} m^2 str".format(detector.name, etendue, etendue_error))
     kb5v_etendues.append((etendue, etendue_error))
 np.save("kb5v_etendue.npy", kb5v_etendues)
 
 
-kb5h = load_kb5_camera('KB5H', parent=world)
+kb5h = load_kb5_camera('KB5H', parent=world, override_material=AbsorbingSurface())
 kb5h_etendues = []
 for detector in kb5h:
-
     etendue, etendue_error = detector.calculate_etendue(ray_count=400000)
     print("Detector {}: etendue {:.4G} +- {:.3G} m^2 str".format(detector.name, etendue, etendue_error))
     kb5h_etendues.append((etendue, etendue_error))

--- a/demos/diagnostic/kb5/calculate_sensitivities.py
+++ b/demos/diagnostic/kb5/calculate_sensitivities.py
@@ -1,25 +1,20 @@
 
 import time
 import numpy as np
-from raysect.primitive import import_obj
 from raysect.optical import World
 from raysect.optical.material import AbsorbingSurface
 from raysect.core.workflow import MulticoreEngine
 
 from cherab.jet.machine import import_jet_mesh
-from cherab.jet.machine.cad_files import KB5V, KB5H
 from cherab.jet.bolometry import load_kb5_camera, load_kb5_voxel_grid
 
 
 world = World()
 inversion_grid = load_kb5_voxel_grid(parent=world, name="KB5 inversion grid")
 import_jet_mesh(world, override_material=AbsorbingSurface())
-kb5v_collimator_mesh = import_obj(KB5V[0][0], scaling=0.001, parent=world, material=AbsorbingSurface())
-kb5h_collimator_mesh = import_obj(KB5H[0][0], scaling=0.001, parent=world, material=AbsorbingSurface())
-
 
 # Calculate KB5V camera sensitivities
-kb5v = load_kb5_camera('KB5V', parent=world)
+kb5v = load_kb5_camera('KB5V', parent=world, override_material=AbsorbingSurface())
 sensitivity_matrix = np.zeros((len(kb5v), inversion_grid.count))
 for i, detector in enumerate(kb5v):
     detector.render_engine = MulticoreEngine(10)
@@ -31,7 +26,7 @@ np.save("kb5v_sensitivities.npy", sensitivity_matrix)
 
 
 # Calculate KB5H camera sensitivities
-kb5h = load_kb5_camera('KB5H', parent=world)
+kb5h = load_kb5_camera('KB5H', parent=world, override_material=AbsorbingSurface())
 sensitivity_matrix = np.zeros((len(kb5h), inversion_grid.count))
 for i, detector in enumerate(kb5h):
     detector.render_engine = MulticoreEngine(10)

--- a/demos/diagnostic/kb5/plot_sightlines.py
+++ b/demos/diagnostic/kb5/plot_sightlines.py
@@ -1,26 +1,20 @@
 
 from math import sqrt
 import matplotlib.pyplot as plt
-from raysect.primitive import import_obj
 from raysect.optical import World
 from raysect.optical.material import AbsorbingSurface
 
 from cherab.jet.machine import import_jet_mesh, plot_jet_wall_outline
-from cherab.jet.machine.cad_files import KB5V, KB5H
 from cherab.jet.bolometry import load_kb5_camera
 
 
 # Calculate KB5V camera sensitivities
 world = World()
 import_jet_mesh(world, override_material=AbsorbingSurface())
-kb5v_collimator_mesh = import_obj(KB5V[0][0], scaling=0.001, name='kb5v_collimator',
-                                  parent=world, material=AbsorbingSurface())
-kb5h_collimator_mesh = import_obj(KB5H[0][0], scaling=0.001, name='kb5h_collimator',
-                                  parent=world, material=AbsorbingSurface())
 
 
 plt.ion()
-kb5v = load_kb5_camera('KB5V', parent=world)
+kb5v = load_kb5_camera('KB5V', parent=world, override_material=AbsorbingSurface())
 for detector in kb5v:
 
     try:
@@ -43,7 +37,7 @@ for detector in kb5v:
 plot_jet_wall_outline()
 
 
-kb5h = load_kb5_camera('KB5H', parent=world)
+kb5h = load_kb5_camera('KB5H', parent=world, override_material=AbsorbingSurface())
 for detector in kb5h:
 
     try:


### PR DESCRIPTION
Load the mesh geometry in load_kb5_camera. There is no way to get
meaningful results unless the mesh geometry is loaded, so it should
not be up to the end user to load the mesh separately.

Fixes #11 