### PR TITLE
Add path parameter to load_kl1/kl11_camera

### DIFF
--- a/cherab/jet/cameras/kl1/load_kl1.py
+++ b/cherab/jet/cameras/kl1/load_kl1.py
@@ -5,9 +5,17 @@ from raysect.optical.observer import PowerPipeline2D, VectorCamera
 from cherab.tools.observers import load_calcam_calibration
 
 
-def load_kl1_camera(parent=None, pipelines=None):
+def load_kl1_camera(parent=None, pipelines=None, stride=1,
+                    calibration_file = '/home/mcarr/cherab/cherab_jet/cherab/jet/cameras/kl1/kl1-e4wc-sightlines.nc'):
+    """
+    Load Camera calibration fron an *.nc file.
 
-    camera_config = load_calcam_calibration('/home/mcarr/cherab/cherab_jet/cherab/jet/cameras/kl1/kl1-e4wc-sightlines.nc')
+    :param parent: parent of the camera observer
+    :param pipeline: camera pipelines
+    :param stride: Binning parameter, only every nth pixel from the calibration is used
+    """
+
+    camera_config = load_calcam_calibration(calibration_file)
 
     if not pipelines:
         power_unfiltered = PowerPipeline2D(display_unsaturated_fraction=0.96, name="Unfiltered Power (W)")
@@ -15,7 +23,7 @@ def load_kl1_camera(parent=None, pipelines=None):
         pipelines = [power_unfiltered]
 
     pixels_shape, pixel_origins, pixel_directions = camera_config
-    camera = VectorCamera(pixel_origins, pixel_directions, pipelines=pipelines, parent=parent)
+    camera = VectorCamera(pixel_origins[::stride, ::stride], pixel_directions[::stride, ::stride], pipelines=pipelines, parent=parent)
     camera.spectral_bins = 15
     camera.pixel_samples = 1
 

--- a/cherab/jet/cameras/kl11/load_kl11.py
+++ b/cherab/jet/cameras/kl11/load_kl11.py
@@ -9,9 +9,20 @@ from cherab.tools.observers import load_calcam_calibration
 from cherab.tools.inversions import ToroidalVoxelGrid
 
 
-def load_kl11_camera(parent=None, pipelines=None, stride=1):
+def load_kl11_camera(parent=None, pipelines=None, stride=1,
+                     calibration_file = '/home/mcarr/cherab/cherab_jet/cherab/jet/cameras/kl11/KL11-E1DC_87516.nc'):
+    """
+    Load Camera calibration fron an *.nc file.
 
-    camera_config = load_calcam_calibration('/home/mcarr/cherab/cherab_jet/cherab/jet/cameras/kl11/KL11-E1DC_87516.nc')
+    :param parent: Parent of the camera observer
+    :param pipeline: Camera pipelines
+    :param stride: Binning parameter, only every nth pixel from the calibration is used
+    :param configuration_file: Path to the camera calibration file
+
+    return
+    """
+
+    camera_config = load_calcam_calibration(calibration_file)
 
     if not pipelines:
         power_unfiltered = PowerPipeline2D(display_unsaturated_fraction=0.96, name="Unfiltered Power (W)")


### PR DESCRIPTION
Currently the methods "load_kl11_camera" and "load_kl1_camera" are hard-linked
 to a specific camera calibration file saved in Matthew Carr's home.
 Adding an optional parameter willallow creating camera with different calibrations.