### PR TITLE
Packaging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.log
+*.npy
+__pycache__
+*.pickle
+*.egg-info
+build
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include cherab *.json *.csv *.pro
+prune demos

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 JET
 ===
 
-Welcome to the CHERAB project. This is the JET specific machine package.
+Welcome to the Cherab project. This is the JET specific machine package.
+
+To install the package, clone the repository and run:
+
+```bash
+pip install <path-to-cherab-jet>
+```
+
+If you wish to develop the package then consider passing the `-e` option to `pip`.
+This will install the package in `develop` mode and make your changes visible without reinstalling the package.
+Please make any changes against the `development` branch.
 
 Please see our [documentation](https://cherab.github.io/documentation/index.html)
 for guidance on using the code.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="cherab-jet",
-    version="1.1.0dev1",
+    version="1.1.0.dev1",
     license="EUPL 1.1",
     namespace_packages=["cherab"],
     description="Cherab spectroscopy framework: JET machine submodule",

--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,34 @@
-from setuptools import setup, find_packages, Extension
-from Cython.Build import cythonize
-import sys
-import numpy
-import os
-import os.path as path
-import multiprocessing
+from setuptools import setup, find_packages
 
-threads = multiprocessing.cpu_count()
-force = False
-profile = False
 
-if "--force" in sys.argv:
-    force = True
-    del sys.argv[sys.argv.index("--force")]
-
-if "--profile" in sys.argv:
-    profile = True
-    del sys.argv[sys.argv.index("--profile")]
-
-compilation_includes = [".", numpy.get_include()]
-
-setup_path = path.dirname(path.abspath(__file__))
-
-# build extension list
-extensions = []
-for root, dirs, files in os.walk(setup_path):
-    for file in files:
-        if path.splitext(file)[1] == ".pyx":
-            pyx_file = path.relpath(path.join(root, file), setup_path)
-            module = path.splitext(pyx_file)[0].replace("/", ".")
-            extensions.append(Extension(module, [pyx_file], include_dirs=compilation_includes),)
-
-if profile:
-    directives = {"profile": True}
-else:
-    directives = {}
+with open("README.md") as f:
+    long_description = f.read()
 
 
 setup(
     name="cherab-jet",
-    version="1.0.0",
+    version="1.1.0dev1",
     license="EUPL 1.1",
-    namespace_packages=['cherab'],
+    namespace_packages=["cherab"],
+    description="Cherab spectroscopy framework: JET machine submodule",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Education",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Physics",
+    ],
+    url="https://github.com/cherab",
+    project_urls=dict(
+        Tracker="https://github.com/cherab/jet/issues",
+        Documentation="https://cherab.github.io/documentation/",
+    ),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
-    ext_modules=cythonize(extensions, nthreads=threads, force=force, compiler_directives=directives)
+    install_requires=["cherab"],
 )
-


### PR DESCRIPTION
Bring the package up to the same standard as cherab-core and cherab-solps. It should be installable with `pip install <path-to-cherab-jet>`. Whilst not yet on PyPI, this could be done at a later date (the license is compatible) if installation and places other than JET is desirable or practical.