### PR TITLE
36 handling default location cadmesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Release 1.1.0 (TBD)
 New:
 * Add KB3 bolometer cameras. (#31)
 
+Changes:
+* Remove `/projects/cadmesh/` from default paths for rsm files. (#36)
+
 Release 1.0.0 (7 Aug 2017)
 --------------------------
 

--- a/cherab/jet/machine/cad_files.py
+++ b/cherab/jet/machine/cad_files.py
@@ -27,12 +27,10 @@ from raysect.optical.library.metal import RoughTungsten, RoughBeryllium, RoughIr
 try:
     CADMESH_PATH = os.environ['CHERAB_CADMESH']
 except KeyError:
-    if os.path.isdir('/projects/cadmesh/'):
-        CADMESH_PATH = '/projects/cadmesh/'
-    elif os.path.isdir('/common/cadmesh'):  # on JDC computers
+    if os.path.isdir('/common/cadmesh'):
         CADMESH_PATH = '/common/cadmesh'
     else:
-        raise ValueError("Can't find '/projects/cadmesh' or '/common/cadmesh': please set the "
+        raise ValueError("Can't find '/common/cadmesh': please set the "
                          "CHERAB_CADMESH environment variable to point to the directory "
                          "which contains JET's RSM mesh files.")
 


### PR DESCRIPTION
This pull request removes the `/projects/cadmesh/` path from the default search paths for RSM files that was kept for old Heimdall nodes. It also updates the error message accordingly.

The changes aim to remove duplicit directories as the other path `/common/cadmesh/` is visible from both old and new nodes.