### PR TITLE
Fix crash caused by unreachable SAL server by adding more SAL options

### DIFF
--- a/cherab/jet/__init__.py
+++ b/cherab/jet/__init__.py
@@ -15,4 +15,4 @@
 # under the Licence.
 
 from .equilibrium import *
-from .sal import sal
+from .sal import JETSALClient, get_jet_sal

--- a/cherab/jet/equilibrium/equilibrium.py
+++ b/cherab/jet/equilibrium/equilibrium.py
@@ -24,7 +24,7 @@ import numpy as np
 from raysect.core import Point2D
 from cherab.tools.equilibrium import EFITEquilibrium
 
-from cherab.jet.sal import sal
+from cherab.jet.sal import JETSALClient
 from sal.core.exception import NodeNotFound
 
 
@@ -46,6 +46,7 @@ class JETEquilibrium:
 
         DDA_PATH = '/pulse/{}/ppf/signal/{}/{}:{}'
         DATA_PATH = '/pulse/{}/ppf/signal/{}/{}/{}:{}'
+        sal = JETSALClient()
 
         # defaults
         user = user or 'jetppf'

--- a/cherab/jet/sal.py
+++ b/cherab/jet/sal.py
@@ -3,5 +3,25 @@ import os
 from sal.client import SALClient
 
 
-sal_server = os.environ.get('JET_SAL_SERVER', 'https://sal.jetdata.eu')
-sal = SALClient(host=sal_server)
+SAL_SERVER = os.environ.get('JET_SAL_SERVER', 'https://sal.jetdata.eu')
+
+
+class JETSALClient(SALClient):
+    """SALClient with host `sal.jetdata.eu` by default, or env variable `JET_SAL_SERVER`."""
+    def __init__(self, host: str = SAL_SERVER, **kwargs):
+        super().__init__(host=host, **kwargs)
+
+
+def get_jet_sal(host: str = SAL_SERVER, **kwargs) -> SALClient:
+    """Creates a SALClient instance connected to `host` if provided.
+    By default uses env variable `JET_SAL_SERVER` if set, `https://sal.jetdata.eu` otherwise.
+    """
+    return SALClient(host=host, **kwargs)
+
+
+def __getattr__(name: str):
+    if name == "sal":
+        value = get_jet_sal()
+        globals()[name] = value  # cache on the module
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Fixes crash when importing cherab.jet while SAL server is unreachable #40 

Adds new subclass and function that check sal reachability only on instantiation or call so that the import of package is unaffectd.

Also adds a custom getattr method of cherab.jet.sal module that allows to use former notation `from cherab.jet.sal import sal`. Usage of this notation is discouraged as it results in the connection error being raised if SAL server is not reachable on import. 